### PR TITLE
enhancement: file can be both a source and a target

### DIFF
--- a/lib/cachebust.js
+++ b/lib/cachebust.js
@@ -41,8 +41,15 @@ const cachebust = async (sourceFiles, targetFiles) => {
   }
 
   if (from.length) {
+    let _targetFiles = targetFiles.map(targetFileName => {
+      let i = sourceFiles.findIndex(sourceFileName =>
+        sourceFileName === targetFileName);
+      return i !== -1 &&
+        `${path.dirname(sourceFiles[i])}/${to[i]}` || targetFileName;
+    });
+
     const changes = replace({
-      files: targetFiles,
+      files: _targetFiles,
       from: from,
       to: to
     });


### PR DESCRIPTION
Please review my feature branch. I have added the ability for files to be both source and target. The use case supported is where, for instance, a .css file is to be fingered and it has content that also needs to be replaced, such as a reference to an image file such as would be found in the url value of a css background-image property.

Looking forward to your follow-up :)

